### PR TITLE
possible fix for path param issue #1

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -171,12 +171,35 @@ awslambda /second/path/ {
 	}
 }
 
+func TestParseFunction(t *testing.T) {
+	for i, test := range []struct {
+		path     string
+		expected string
+	}{
+		{"/foo/bar", "bar"},
+		{"/foo/bar/baz", "bar"},
+		{"/foo", ""},
+		{"/foo/", ""},
+		{"/foo/bar?a=b", "bar"},
+		{"/foo/bar#anchor-here", "bar"},
+		{"/foo/bar?a=/blah#anchor-here", "bar"},
+		{"/foo/bar/baz?a=/blah#anchor-here", "bar"},
+	} {
+		c := Config{Path: "/foo/"}
+		actual := c.ParseFunction(test.path)
+		if actual != test.expected {
+			t.Errorf("\nTest %d\nExpected: %s\n  Actual: %s", i, test.expected, actual)
+		}
+	}
+}
+
 func TestMaybeToInvokeInput(t *testing.T) {
 	r1 := mustNewRequest("PUT", "/api/user", bytes.NewBufferString("hello world"))
 	r2 := mustNewRequest("PUT", "/api/user", bytes.NewBufferString("hello world"))
 
 	// expect a non-nil input
 	c := Config{
+		Path:        "/api/",
 		NamePrepend: "before-",
 		NameAppend:  "-after",
 		Qualifier:   "prod",

--- a/lambda.go
+++ b/lambda.go
@@ -2,7 +2,6 @@ package awslambda
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
@@ -91,25 +90,4 @@ func (h Handler) match(r *http.Request) (*Config, *lambda.InvokeInput, error) {
 		}
 	}
 	return c, invokeInput, nil
-}
-
-// ParseFunction returns the fragment of path that occurs after
-// the last '/' character, excluding query string and named anchors.
-//
-// For example, given a path of '/lambda/my-func?a=/foo', ParseFunction returns 'my-func'
-func ParseFunction(path string) string {
-	pos := strings.Index(path, "?")
-	if pos > -1 {
-		path = path[:pos]
-	}
-	pos = strings.Index(path, "#")
-	if pos > -1 {
-		path = path[:pos]
-	}
-
-	pos = strings.LastIndex(path, "/")
-	if pos == -1 {
-		return path
-	}
-	return path[pos+1:]
 }

--- a/lambda_test.go
+++ b/lambda_test.go
@@ -62,25 +62,6 @@ func TestInvokeInvalidFunc(t *testing.T) {
 	}
 }
 
-func TestParseFunction(t *testing.T) {
-	for i, test := range []struct {
-		path     string
-		expected string
-	}{
-		{"/foo/bar", "bar"},
-		{"/foo/bar/baz", "baz"},
-		{"blah", "blah"},
-		{"/foo/bar?a=b", "bar"},
-		{"/foo/bar#anchor-here", "bar"},
-		{"/foo/bar?a=/blah#anchor-here", "bar"},
-	} {
-		actual := ParseFunction(test.path)
-		if actual != test.expected {
-			t.Errorf("\nTest %d\nExpected: %s\n  Actual: %s", i, test.expected, actual)
-		}
-	}
-}
-
 ////////////////////////////////////////
 
 func marshalJSON(i interface{}) []byte {


### PR DESCRIPTION
I don't have a full-blown setup to test Caddy with these changes, but the change might look something like this.  I think the ParseFunction needs to have the Config.Path in order to trim off the route prefix, so I moved it to be a method attached to that struct... the rest of the changes, including tests should be self-evident.   Obvious bugs / problems may exist - this was a quick and dirty.
