### PR TITLE
implement header_upstream directive with caddyfile placeholder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ awslambda <path-prefix> {
     name_append        string to append to function name
     single             name of a single lambda function to invoke
     strip_path_prefix  If true, path and function name are stripped from the path
+    header_upstream    header-name header-value
 }
 ```
 
@@ -61,6 +62,12 @@ awslambda <path-prefix> {
 *   **name_append** is an optional string to append to the function name parsed from the URL before invoking the Lambda.
 *   **single** is an optional function name. If set, function name is not parsed from the URI path.
 *   **strip_path_prefix** If 'true', path and function name is stripped from the path sent as request metadata to the Lambda function. (default=false)
+*   **header_upstream** Inject "header" key-value pairs into the upstream request json. Supports usage of caddyfile placeholders. Can be used multiple times. Comes handy with frameworks like express. Example:
+   ```
+   header_upstream X-Forwarded-For {remote}
+   header_upstream X-Forwarded-Host {hostonly}
+   header_upstream X-Forwarded-Proto {scheme}
+   ```
 
 Function names are parsed from the portion of request path following the path-prefix in the
 directive based on this convention: `[path-prefix]/[function-name]/[extra-path-info]` unless `single` attribute is set.


### PR DESCRIPTION
I implemented the header_upstream directive from issue #4, but PLEASE review what I did, because I'm not good with go! ;)
Rudimentary tests and docs included.

I also wrote a compatibility layer for aws-serverless-express here: https://www.npmjs.com/package/@erdii/caddy-serverless-express