### PR TITLE
travis.yml: update go 1.8 to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.8
+- 1.10
 - tip
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.10
+- "1.10"
 - tip
 
 before_script:


### PR DESCRIPTION
Looks like Caddy no longer builds with 1.8.  Its README claims it supports 1.10 or higher, so let's try that.