### PR TITLE
lambda.go: do not return status if >= 400 to prevent DefaultErrorFunc from running

### DIFF
--- a/lambda.go
+++ b/lambda.go
@@ -75,7 +75,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 
 	// Write the response body
 	_, err = w.Write(bodyBytes)
-	if err != nil {
+	if err != nil || reply.Meta.Status >= 400 {
 		return 0, err
 	}
 


### PR DESCRIPTION
This hopefully fixes #6 

If the status is >= 400 then return 0 from this function to tell caddy not to run the `DefaultErrorFunc` 